### PR TITLE
renaming

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1781,6 +1781,7 @@
       "requires": {
         "anymatch": "1.3.2",
         "async-each": "1.0.1",
+        "fsevents": "1.1.3",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -3962,6 +3963,794 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "fsevents": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+      "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+      "optional": true,
+      "requires": {
+        "nan": "2.8.0",
+        "node-pre-gyp": "0.6.39"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.0",
+          "bundled": true,
+          "optional": true
+        },
+        "ajv": {
+          "version": "4.11.8",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
+          }
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "aproba": {
+          "version": "1.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.2.9"
+          }
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "bundled": true,
+          "optional": true
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "bundled": true,
+          "optional": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "bundled": true,
+          "optional": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "bundled": true,
+          "optional": true
+        },
+        "aws4": {
+          "version": "1.6.0",
+          "bundled": true,
+          "optional": true
+        },
+        "balanced-match": {
+          "version": "0.4.2",
+          "bundled": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "tweetnacl": "0.14.5"
+          }
+        },
+        "block-stream": {
+          "version": "0.0.9",
+          "bundled": true,
+          "requires": {
+            "inherits": "2.0.3"
+          }
+        },
+        "boom": {
+          "version": "2.10.1",
+          "bundled": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.7",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "0.4.2",
+            "concat-map": "0.0.1"
+          }
+        },
+        "buffer-shims": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "bundled": true,
+          "optional": true
+        },
+        "co": {
+          "version": "4.6.0",
+          "bundled": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "bundled": true,
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "bundled": true,
+          "requires": {
+            "boom": "2.10.1"
+          }
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "debug": {
+          "version": "2.6.8",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "bundled": true,
+          "optional": true
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "extend": {
+          "version": "3.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "extsprintf": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true,
+          "optional": true
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.15"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "fstream": {
+          "version": "1.0.11",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.1"
+          }
+        },
+        "fstream-ignore": {
+          "version": "1.0.5",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "fstream": "1.0.11",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4"
+          }
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "aproba": "1.1.1",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          }
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true
+        },
+        "har-schema": {
+          "version": "1.0.5",
+          "bundled": true,
+          "optional": true
+        },
+        "har-validator": {
+          "version": "4.2.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "bundled": true,
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "bundled": true
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.0",
+            "sshpk": "1.13.0"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "ini": {
+          "version": "1.3.4",
+          "bundled": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true,
+          "optional": true
+        },
+        "jodid25519": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "bundled": true,
+          "optional": true
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "jsonify": "0.0.0"
+          }
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "jsonify": {
+          "version": "0.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "jsprim": {
+          "version": "1.4.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.0.2",
+            "json-schema": "0.2.3",
+            "verror": "1.3.6"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "mime-db": {
+          "version": "1.27.0",
+          "bundled": true
+        },
+        "mime-types": {
+          "version": "2.1.15",
+          "bundled": true,
+          "requires": {
+            "mime-db": "1.27.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "node-pre-gyp": {
+          "version": "0.6.39",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "1.0.2",
+            "hawk": "3.1.3",
+            "mkdirp": "0.5.1",
+            "nopt": "4.0.1",
+            "npmlog": "4.1.0",
+            "rc": "1.2.1",
+            "request": "2.81.0",
+            "rimraf": "2.6.1",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "tar-pack": "3.4.0"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1.1.0",
+            "osenv": "0.1.4"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "bundled": true,
+          "optional": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "performance-now": {
+          "version": "0.2.0",
+          "bundled": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "bundled": true
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "bundled": true,
+          "optional": true
+        },
+        "qs": {
+          "version": "6.4.0",
+          "bundled": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "0.4.2",
+            "ini": "1.3.4",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.2.9",
+          "bundled": true,
+          "requires": {
+            "buffer-shims": "1.0.0",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "1.0.1",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "request": {
+          "version": "2.81.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.15",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.0.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.2",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.1",
+          "bundled": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.0.1",
+          "bundled": true
+        },
+        "semver": {
+          "version": "5.3.0",
+          "bundled": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "bundled": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "sshpk": {
+          "version": "1.13.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.1",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jodid25519": "1.0.2",
+            "jsbn": "0.1.1",
+            "tweetnacl": "0.14.5"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "bundled": true,
+          "optional": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "2.2.1",
+          "bundled": true,
+          "requires": {
+            "block-stream": "0.0.9",
+            "fstream": "1.0.11",
+            "inherits": "2.0.3"
+          }
+        },
+        "tar-pack": {
+          "version": "3.4.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "debug": "2.6.8",
+            "fstream": "1.0.11",
+            "fstream-ignore": "1.0.5",
+            "once": "1.4.0",
+            "readable-stream": "2.2.9",
+            "rimraf": "2.6.1",
+            "tar": "2.2.1",
+            "uid-number": "0.0.6"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.3.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "bundled": true,
+          "optional": true
+        },
+        "uid-number": {
+          "version": "0.0.6",
+          "bundled": true,
+          "optional": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "uuid": {
+          "version": "3.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "verror": {
+          "version": "1.3.6",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "extsprintf": "1.0.2"
+          }
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        }
+      }
     },
     "fstream": {
       "version": "1.0.11",
@@ -9193,6 +9982,7 @@
         "extract-text-webpack-plugin": "3.0.2",
         "file-loader": "1.1.5",
         "fs-extra": "3.0.1",
+        "fsevents": "1.1.2",
         "html-webpack-plugin": "2.29.0",
         "jest": "20.0.4",
         "object-assign": "4.1.1",
@@ -9210,6 +10000,791 @@
         "whatwg-fetch": "2.0.3"
       },
       "dependencies": {
+        "fsevents": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
+          "integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
+          "optional": true,
+          "requires": {
+            "nan": "2.8.0",
+            "node-pre-gyp": "0.6.36"
+          },
+          "dependencies": {
+            "abbrev": {
+              "version": "1.1.0",
+              "bundled": true,
+              "optional": true
+            },
+            "ajv": {
+              "version": "4.11.8",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "co": "4.6.0",
+                "json-stable-stringify": "1.0.1"
+              }
+            },
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "aproba": {
+              "version": "1.1.1",
+              "bundled": true,
+              "optional": true
+            },
+            "are-we-there-yet": {
+              "version": "1.1.4",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "delegates": "1.0.0",
+                "readable-stream": "2.2.9"
+              }
+            },
+            "asn1": {
+              "version": "0.2.3",
+              "bundled": true,
+              "optional": true
+            },
+            "assert-plus": {
+              "version": "0.2.0",
+              "bundled": true,
+              "optional": true
+            },
+            "asynckit": {
+              "version": "0.4.0",
+              "bundled": true,
+              "optional": true
+            },
+            "aws-sign2": {
+              "version": "0.6.0",
+              "bundled": true,
+              "optional": true
+            },
+            "aws4": {
+              "version": "1.6.0",
+              "bundled": true,
+              "optional": true
+            },
+            "balanced-match": {
+              "version": "0.4.2",
+              "bundled": true
+            },
+            "bcrypt-pbkdf": {
+              "version": "1.0.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "tweetnacl": "0.14.5"
+              }
+            },
+            "block-stream": {
+              "version": "0.0.9",
+              "bundled": true,
+              "requires": {
+                "inherits": "2.0.3"
+              }
+            },
+            "boom": {
+              "version": "2.10.1",
+              "bundled": true,
+              "requires": {
+                "hoek": "2.16.3"
+              }
+            },
+            "brace-expansion": {
+              "version": "1.1.7",
+              "bundled": true,
+              "requires": {
+                "balanced-match": "0.4.2",
+                "concat-map": "0.0.1"
+              }
+            },
+            "buffer-shims": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "caseless": {
+              "version": "0.12.0",
+              "bundled": true,
+              "optional": true
+            },
+            "co": {
+              "version": "4.6.0",
+              "bundled": true,
+              "optional": true
+            },
+            "code-point-at": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "combined-stream": {
+              "version": "1.0.5",
+              "bundled": true,
+              "requires": {
+                "delayed-stream": "1.0.0"
+              }
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "bundled": true
+            },
+            "console-control-strings": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "core-util-is": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "cryptiles": {
+              "version": "2.0.5",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "boom": "2.10.1"
+              }
+            },
+            "dashdash": {
+              "version": "1.14.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "assert-plus": "1.0.0"
+              },
+              "dependencies": {
+                "assert-plus": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "optional": true
+                }
+              }
+            },
+            "debug": {
+              "version": "2.6.8",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "deep-extend": {
+              "version": "0.4.2",
+              "bundled": true,
+              "optional": true
+            },
+            "delayed-stream": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "delegates": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "ecc-jsbn": {
+              "version": "0.1.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "jsbn": "0.1.1"
+              }
+            },
+            "extend": {
+              "version": "3.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "extsprintf": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "forever-agent": {
+              "version": "0.6.1",
+              "bundled": true,
+              "optional": true
+            },
+            "form-data": {
+              "version": "2.1.4",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "asynckit": "0.4.0",
+                "combined-stream": "1.0.5",
+                "mime-types": "2.1.15"
+              }
+            },
+            "fs.realpath": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "fstream": {
+              "version": "1.0.11",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "4.1.11",
+                "inherits": "2.0.3",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.1"
+              }
+            },
+            "fstream-ignore": {
+              "version": "1.0.5",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "fstream": "1.0.11",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4"
+              }
+            },
+            "gauge": {
+              "version": "2.7.4",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "aproba": "1.1.1",
+                "console-control-strings": "1.1.0",
+                "has-unicode": "2.0.1",
+                "object-assign": "4.1.1",
+                "signal-exit": "3.0.2",
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1",
+                "wide-align": "1.1.2"
+              }
+            },
+            "getpass": {
+              "version": "0.1.7",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "assert-plus": "1.0.0"
+              },
+              "dependencies": {
+                "assert-plus": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "optional": true
+                }
+              }
+            },
+            "glob": {
+              "version": "7.1.2",
+              "bundled": true,
+              "requires": {
+                "fs.realpath": "1.0.0",
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
+              }
+            },
+            "graceful-fs": {
+              "version": "4.1.11",
+              "bundled": true
+            },
+            "har-schema": {
+              "version": "1.0.5",
+              "bundled": true,
+              "optional": true
+            },
+            "har-validator": {
+              "version": "4.2.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "ajv": "4.11.8",
+                "har-schema": "1.0.5"
+              }
+            },
+            "has-unicode": {
+              "version": "2.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "hawk": {
+              "version": "3.1.3",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "boom": "2.10.1",
+                "cryptiles": "2.0.5",
+                "hoek": "2.16.3",
+                "sntp": "1.0.9"
+              }
+            },
+            "hoek": {
+              "version": "2.16.3",
+              "bundled": true
+            },
+            "http-signature": {
+              "version": "1.1.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "assert-plus": "0.2.0",
+                "jsprim": "1.4.0",
+                "sshpk": "1.13.0"
+              }
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "bundled": true,
+              "requires": {
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
+              }
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "bundled": true
+            },
+            "ini": {
+              "version": "1.3.4",
+              "bundled": true,
+              "optional": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "number-is-nan": "1.0.1"
+              }
+            },
+            "is-typedarray": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "isstream": {
+              "version": "0.1.2",
+              "bundled": true,
+              "optional": true
+            },
+            "jodid25519": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "jsbn": "0.1.1"
+              }
+            },
+            "jsbn": {
+              "version": "0.1.1",
+              "bundled": true,
+              "optional": true
+            },
+            "json-schema": {
+              "version": "0.2.3",
+              "bundled": true,
+              "optional": true
+            },
+            "json-stable-stringify": {
+              "version": "1.0.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "jsonify": "0.0.0"
+              }
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "jsonify": {
+              "version": "0.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "jsprim": {
+              "version": "1.4.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "assert-plus": "1.0.0",
+                "extsprintf": "1.0.2",
+                "json-schema": "0.2.3",
+                "verror": "1.3.6"
+              },
+              "dependencies": {
+                "assert-plus": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "optional": true
+                }
+              }
+            },
+            "mime-db": {
+              "version": "1.27.0",
+              "bundled": true
+            },
+            "mime-types": {
+              "version": "2.1.15",
+              "bundled": true,
+              "requires": {
+                "mime-db": "1.27.0"
+              }
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "bundled": true,
+              "requires": {
+                "brace-expansion": "1.1.7"
+              }
+            },
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "bundled": true,
+              "requires": {
+                "minimist": "0.0.8"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "node-pre-gyp": {
+              "version": "0.6.36",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "mkdirp": "0.5.1",
+                "nopt": "4.0.1",
+                "npmlog": "4.1.0",
+                "rc": "1.2.1",
+                "request": "2.81.0",
+                "rimraf": "2.6.1",
+                "semver": "5.3.0",
+                "tar": "2.2.1",
+                "tar-pack": "3.4.0"
+              }
+            },
+            "nopt": {
+              "version": "4.0.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "abbrev": "1.1.0",
+                "osenv": "0.1.4"
+              }
+            },
+            "npmlog": {
+              "version": "4.1.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "are-we-there-yet": "1.1.4",
+                "console-control-strings": "1.1.0",
+                "gauge": "2.7.4",
+                "set-blocking": "2.0.0"
+              }
+            },
+            "number-is-nan": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "oauth-sign": {
+              "version": "0.8.2",
+              "bundled": true,
+              "optional": true
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true,
+              "optional": true
+            },
+            "once": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "wrappy": "1.0.2"
+              }
+            },
+            "os-homedir": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "os-tmpdir": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "osenv": {
+              "version": "0.1.4",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "os-homedir": "1.0.2",
+                "os-tmpdir": "1.0.2"
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "performance-now": {
+              "version": "0.2.0",
+              "bundled": true,
+              "optional": true
+            },
+            "process-nextick-args": {
+              "version": "1.0.7",
+              "bundled": true
+            },
+            "punycode": {
+              "version": "1.4.1",
+              "bundled": true,
+              "optional": true
+            },
+            "qs": {
+              "version": "6.4.0",
+              "bundled": true,
+              "optional": true
+            },
+            "rc": {
+              "version": "1.2.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "deep-extend": "0.4.2",
+                "ini": "1.3.4",
+                "minimist": "1.2.0",
+                "strip-json-comments": "2.0.1"
+              },
+              "dependencies": {
+                "minimist": {
+                  "version": "1.2.0",
+                  "bundled": true,
+                  "optional": true
+                }
+              }
+            },
+            "readable-stream": {
+              "version": "2.2.9",
+              "bundled": true,
+              "requires": {
+                "buffer-shims": "1.0.0",
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "1.0.0",
+                "process-nextick-args": "1.0.7",
+                "string_decoder": "1.0.1",
+                "util-deprecate": "1.0.2"
+              }
+            },
+            "request": {
+              "version": "2.81.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "aws-sign2": "0.6.0",
+                "aws4": "1.6.0",
+                "caseless": "0.12.0",
+                "combined-stream": "1.0.5",
+                "extend": "3.0.1",
+                "forever-agent": "0.6.1",
+                "form-data": "2.1.4",
+                "har-validator": "4.2.1",
+                "hawk": "3.1.3",
+                "http-signature": "1.1.1",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.15",
+                "oauth-sign": "0.8.2",
+                "performance-now": "0.2.0",
+                "qs": "6.4.0",
+                "safe-buffer": "5.0.1",
+                "stringstream": "0.0.5",
+                "tough-cookie": "2.3.2",
+                "tunnel-agent": "0.6.0",
+                "uuid": "3.0.1"
+              }
+            },
+            "rimraf": {
+              "version": "2.6.1",
+              "bundled": true,
+              "requires": {
+                "glob": "7.1.2"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.0.1",
+              "bundled": true
+            },
+            "semver": {
+              "version": "5.3.0",
+              "bundled": true,
+              "optional": true
+            },
+            "set-blocking": {
+              "version": "2.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "signal-exit": {
+              "version": "3.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "sntp": {
+              "version": "1.0.9",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "hoek": "2.16.3"
+              }
+            },
+            "sshpk": {
+              "version": "1.13.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "asn1": "0.2.3",
+                "assert-plus": "1.0.0",
+                "bcrypt-pbkdf": "1.0.1",
+                "dashdash": "1.14.1",
+                "ecc-jsbn": "0.1.1",
+                "getpass": "0.1.7",
+                "jodid25519": "1.0.2",
+                "jsbn": "0.1.1",
+                "tweetnacl": "0.14.5"
+              },
+              "dependencies": {
+                "assert-plus": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "optional": true
+                }
+              }
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "5.0.1"
+              }
+            },
+            "stringstream": {
+              "version": "0.0.5",
+              "bundled": true,
+              "optional": true
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "2.1.1"
+              }
+            },
+            "strip-json-comments": {
+              "version": "2.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "tar": {
+              "version": "2.2.1",
+              "bundled": true,
+              "requires": {
+                "block-stream": "0.0.9",
+                "fstream": "1.0.11",
+                "inherits": "2.0.3"
+              }
+            },
+            "tar-pack": {
+              "version": "3.4.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "debug": "2.6.8",
+                "fstream": "1.0.11",
+                "fstream-ignore": "1.0.5",
+                "once": "1.4.0",
+                "readable-stream": "2.2.9",
+                "rimraf": "2.6.1",
+                "tar": "2.2.1",
+                "uid-number": "0.0.6"
+              }
+            },
+            "tough-cookie": {
+              "version": "2.3.2",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "punycode": "1.4.1"
+              }
+            },
+            "tunnel-agent": {
+              "version": "0.6.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "safe-buffer": "5.0.1"
+              }
+            },
+            "tweetnacl": {
+              "version": "0.14.5",
+              "bundled": true,
+              "optional": true
+            },
+            "uid-number": {
+              "version": "0.0.6",
+              "bundled": true,
+              "optional": true
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "uuid": {
+              "version": "3.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "verror": {
+              "version": "1.3.6",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "extsprintf": "1.0.2"
+              }
+            },
+            "wide-align": {
+              "version": "1.1.2",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "string-width": "1.0.2"
+              }
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "bundled": true
+            }
+          }
+        },
         "promise": {
           "version": "8.0.1",
           "resolved": "https://registry.npmjs.org/promise/-/promise-8.0.1.tgz",

--- a/src/App.js
+++ b/src/App.js
@@ -1,8 +1,8 @@
 import React, { Component } from 'react';
 
 import TopNav from './components/TopNav';
-import LineSearch from './components/LineSearch';
-import Nearby from './components/Nearby'
+import RouteSearch from './components/RouteSearch';
+import Nearby from './components/Nearby';
 
 class App extends Component {
   
@@ -10,10 +10,10 @@ class App extends Component {
     return (
       <div className="App">
         <TopNav />
-        <LineSearch />
+        <RouteSearch />
         <Nearby />
       </div>
-    );
+    )
   }
 }
 

--- a/src/components/About.js
+++ b/src/components/About.js
@@ -8,8 +8,8 @@ const About = () => (
     <div className="ml4">
       <h1>About</h1>
       <p>Route-Explorer is a beta project between DoIT and DDOT to make bus schedules easier to access and more dynamic by incorporating real-time data.</p>
-      <p>It will replace the PDF links on this City webpage:
-        <a className="black dim hover-mid-gray" href="http://www.detroitmi.gov/How-Do-I/Locate-Transportation/Bus-Schedules" target="_blank" rel="noopener noreferrer"> http://www.detroitmi.gov/How-Do-I/Locate-Transportation/Bus-Schedules</a>
+      <p>It will replace the PDF links on this City webpage: <a className="black dim hover-mid-gray" href="http://www.detroitmi.gov/How-Do-I/Locate-Transportation/Bus-Schedules" 
+        target="_blank" rel="noopener noreferrer">http://www.detroitmi.gov/How-Do-I/Locate-Transportation/Bus-Schedules</a>
       </p>
       <p>See our project roadmap and share feedback on <a className="black dim hover-mid-gray" href="https://github.com/CityOfDetroit/route-explorer" target="_blank" rel="noopener noreferrer">Github</a>.</p>
     </div>

--- a/src/components/BusRouteStopList.js
+++ b/src/components/BusRouteStopList.js
@@ -1,12 +1,10 @@
-import React, { Component } from 'react';
-import _ from 'lodash';
-// import PropTypes from 'prop-types';
-import StopLink from './StopLink';
-// import Schedules from '../data/schedules.js';
+import React, { Component } from 'react'
+import _ from 'lodash'
+
+import StopLink from './StopLink'
 import Stops from '../data/stops.js'
 
 class BusRouteStopList extends Component {
-
   constructor(props) {
     super(props)
     this.state = {
@@ -18,10 +16,11 @@ class BusRouteStopList extends Component {
     fetch(`https://ddot-proxy-test.herokuapp.com/api/where/stops-for-route/DDOT_${this.props.id}.json?key=BETA`)
     .then(response => response.json())
     .then(d => {
-      console.log(d)
-      this.setState({ stops: d.data.entry.stopGroupings[0].stopGroups })
+      this.setState({ 
+        stops: d.data.entry.stopGroupings[0].stopGroups
+      })
     })
-    .catch(e => console.log(e));
+    .catch(e => console.log(e))
   }
 
   componentDidMount() {
@@ -29,17 +28,15 @@ class BusRouteStopList extends Component {
   }
 
   render() {
-    // const stops = _.filter(this.state.stops, ['stopIds[0]', `DDOT_${this.props.timepoints[0]}`])
     const first_timepoint = this.props.timepoints[2]
-    console.log(_.filter(this.state.stops, o => { return o.stopIds.indexOf(`DDOT_${first_timepoint}`) > -1 }))
-    const stops = _.filter(this.state.stops, o => { return o.stopIds.indexOf(`DDOT_${first_timepoint}`) > -1 })
-    console.log(first_timepoint)
-    // const stops = _.filter(this.state.stops, function(o) { return o.stopIds.indexOf(`DDOT_${this.props.timepoints[0]}`) > -1 })
+    const stops = _.filter(this.state.stops, o => { 
+      return o.stopIds.indexOf(`DDOT_${first_timepoint}`) > -1 })
+    
     return (
       <div className='stopList overflow-scroll'>
-        <div className="">
+        <div>
           {stops.length > 0 ? stops[0].stopIds.map((stop, i) =>
-            <div className="pa1 bb b--light-silver" style={{display: 'flex', alignItems: 'center'}}>
+            <div className="pa1 bb b--light-silver" style={{ display: 'flex', alignItems: 'center' }} key={i}>
               <span className="f7 fw7 pa1">{i+1}.</span>
               <StopLink id={stop.slice(5,)} name={Stops[stop.slice(5,)].name} exclude={this.props.routeNumber}/>
             </div>
@@ -50,4 +47,4 @@ class BusRouteStopList extends Component {
   }
 }
 
-export default BusRouteStopList;
+export default BusRouteStopList

--- a/src/components/Legend.js
+++ b/src/components/Legend.js
@@ -1,17 +1,17 @@
-import React from 'react';
+import React from 'react'
 
-let downtownStyle = { backgroundColor: '#44aa42' };
-let ewStyle = { backgroundColor: '#0079c2' };
-let nsStyle = { backgroundColor: '#9b5ba5' };
-let specialStyle = { backgroundColor: '#d07c32' };
+let downtownStyle = { backgroundColor: '#44aa42' }
+let ewStyle = { backgroundColor: '#0079c2' }
+let nsStyle = { backgroundColor: '#9b5ba5' }
+let specialStyle = { backgroundColor: '#d07c32' }
 
-const LineColorLegend = () => (
+const Legend = () => (
   <div className="fw7 legend">
     <div className="ma2 pa2 br2 white" style={downtownStyle}>Routes that go downtown</div>
     <div className="ma2 pa2 br2 white" style={ewStyle}>Routes that go East-West, not downtown</div>
     <div className="ma2 pa2 br2 white" style={nsStyle}>Routes that go North-South, not downtown</div>
     <div className="ma2 pa2 br2 white" style={specialStyle}>Special routes</div>
   </div>
-);
+)
 
-export default LineColorLegend;
+export default Legend

--- a/src/components/LineHeader.js
+++ b/src/components/LineHeader.js
@@ -1,11 +1,14 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom'
+
 import ddotRoutes from '../data/routes.js'
 
 const LineHeader = ({ color, number, name }) => (
   <div className="pv3 ph3 bg-white bg-o-50 header bb">
-    <div style={{display: 'flex', alignItems: 'center'}}>
-      <Link className="link dim dark-gray v-mid mr2" to={{pathname: `/`}}><div className="fw7 f7 f6-ns pa2 bg-moon-gray ba">&lt;</div></Link>
+    <div style={{ display: 'flex', alignItems: 'center' }}>
+      <Link className="link dim dark-gray v-mid mr2" to={{pathname: `/`}}>
+        <div className="fw7 f7 f6-ns pa2 bg-moon-gray ba">&lt;</div>
+      </Link>
       <span className="dib f3-s f2-ns mh2 pa2 v-mid white fw7" style={{ backgroundColor: color }}>
         {number}
       </span>

--- a/src/components/LineLink.js
+++ b/src/components/LineLink.js
@@ -1,19 +1,23 @@
-import React, { Component } from 'react';
-import { Link } from 'react-router-dom';
-import PropTypes from 'prop-types';
+import React, { Component } from 'react'
+import { Link } from 'react-router-dom'
+import PropTypes from 'prop-types'
+
 import Schedules from '../data/schedules.js'
 
 class LineLink extends Component {
   render() {
     const route = Schedules[this.props.id]
+
     return (
-      <div style={{display: 'flex', alignItems:'center'}}>
-        <span className='white fw7 f5 w2 pv2 tc' style={{backgroundColor: route.color}}>
+      <div style={{ display: 'flex', alignItems:'center' }}>
+        <span className='white fw7 f5 w2 pv2 tc' style={{ backgroundColor: route.color }}>
           {this.props.id}
         </span> 
         <span className='tr pl1 f5 fw6 pl2 glow'>
-          <Link className="dim black hover-mid-gray glow" to={{pathname: `/route/${this.props.id}/real-time`, 
-            state: { id: this.props.id, routeId: route.rt_id, name: route.rt_name }}}>{route.rt_name}</Link>
+          <Link 
+            className="dim black hover-mid-gray glow" 
+            to={{ pathname: `/route/${this.props.id}/real-time`, state: { id: this.props.id, routeId: route.rt_id, name: route.rt_name } }}>
+              {route.rt_name}</Link>
         </span>
       </div>
     )
@@ -21,7 +25,7 @@ class LineLink extends Component {
 }
 
 LineLink.propTypes = {
-  id: PropTypes.string.isRequired
+  id: PropTypes.string.isRequired,
 }
 
-export default LineLink;
+export default LineLink

--- a/src/components/LineRealTime.js
+++ b/src/components/LineRealTime.js
@@ -5,7 +5,7 @@ import _ from 'lodash'
 
 import RouteMap from './RouteMap'
 import RealtimeTripList from './RealtimeTripList'
-import LineHeader from './LineHeader'
+import RouteHeader from './RouteHeader'
 import Helpers from '../helpers'
 
 class LineRealTime extends React.Component {
@@ -103,7 +103,7 @@ class LineRealTime extends React.Component {
   render() {
     return (
       <div className="App">
-        <LineHeader color={this.state.color} number={this.props.match.params.name} name={this.state.routeName} />
+        <RouteHeader color={this.state.color} number={this.props.match.params.name} name={this.state.routeName} />
         <RouteMap 
           routeId={this.props.match.params.name} 
           stops={this.state.timepointStops} 

--- a/src/components/LineRealTime.js
+++ b/src/components/LineRealTime.js
@@ -1,21 +1,20 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import moment from 'moment';
-import _ from 'lodash';
+import React from 'react'
+import PropTypes from 'prop-types'
+import moment from 'moment'
+import _ from 'lodash'
 
-import RouteMap from './RouteMap';
-import RealtimeTripList from './RealtimeTripList';
-import LineHeader from './LineHeader';
-
-import Helpers from '../helpers';
+import RouteMap from './RouteMap'
+import RealtimeTripList from './RealtimeTripList'
+import LineHeader from './LineHeader'
+import Helpers from '../helpers'
 
 class LineRealTime extends React.Component {
   constructor(props) {
-    super(props);
+    super(props)
 
     let route = Helpers.getRoute(parseInt(this.props.match.params.name, 10))
-
     let tripIds = {}
+    
     Object.keys(route.schedules).forEach(svc => {
       Object.keys(route.schedules.weekday).forEach(dir => {
         if (!tripIds[dir]) {
@@ -42,10 +41,10 @@ class LineRealTime extends React.Component {
       availableDirections: (Object.keys(route.schedules.weekday)),
       routeBbox: route.bbox,
       timepointStops: route.timepoints[Object.keys(route.schedules.weekday)[0]]
-    };
+    }
 
-    this.handleDirectionChange = this.handleDirectionChange.bind(this);
-    this.handleServiceChange = this.handleServiceChange.bind(this);
+    this.handleDirectionChange = this.handleDirectionChange.bind(this)
+    this.handleServiceChange = this.handleServiceChange.bind(this)
   }
 
   fetchData() {
@@ -60,7 +59,6 @@ class LineRealTime extends React.Component {
             "coordinates": [bus.status.position.lon, bus.status.position.lat]
           },
           "properties": {
-            // "letter": _.capitalize(String.fromCharCode(97 + i)),
             "tripId": bus.status.activeTripId,
             "displayTripId": bus.status.activeTripId.slice(-4,),
             "scheduledDistanceAlongTrip": bus.status.scheduledDistanceAlongTrip,
@@ -73,30 +71,29 @@ class LineRealTime extends React.Component {
           }
         }
       })
-
       let realtimeTrips = _.filter(geojson, o => { return o.properties.direction !== undefined })
-
-      this.setState({realtimeTrips: realtimeTrips})
-
+      this.setState({ 
+        realtimeTrips: realtimeTrips 
+      })
     })
-    .catch(e => console.log(e));
+    .catch(e => console.log(e))
   }
 
   handleDirectionChange(event) {
     this.setState({
       currentDirection: event.target.value
-    });
+    })
   }
 
   handleServiceChange(event) {
     this.setState({
       currentSvc: event.target.value
-    });
+    })
   }
 
   componentDidMount() {
     this.fetchData()
-    this.interval = setInterval(() => this.fetchData(), 3000);
+    this.interval = setInterval(() => this.fetchData(), 3000)
   }
 
   componentWillUnmount() {
@@ -133,4 +130,4 @@ LineRealTime.propTypes = {
   }).isRequired,
 }
 
-export default LineRealTime;
+export default LineRealTime

--- a/src/components/LineSchedule.js
+++ b/src/components/LineSchedule.js
@@ -6,8 +6,8 @@ import _ from 'lodash';
 import ScheduleTable from './ScheduleTable';
 import ServicePicker from './ServicePicker';
 import DirectionPicker from './DirectionPicker';
-import LineHeader from './LineHeader';
-import BusRouteStopList from './BusRouteStopList'
+import RouteHeader from './RouteHeader';
+import RouteStopList from './RouteStopList'
 
 import Helpers from '../helpers';
 
@@ -104,7 +104,7 @@ class LineSchedule extends React.Component {
   render() {
     return (
       <div className="App">
-        <LineHeader color={this.state.color} number={this.props.match.params.name} name={this.state.routeName} />
+        <RouteHeader color={this.state.color} number={this.props.match.params.name} name={this.state.routeName} />
         <div className="pickers">
           <ServicePicker 
             services={this.state.availableServices}
@@ -116,10 +116,9 @@ class LineSchedule extends React.Component {
             currentDirection={this.state.currentDirection}
             onChange={this.handleDirectionChange} 
           />
-                  <h2>Stops on this schedule</h2>
-
+          <h2>Stops on this schedule</h2>
         </div>
-        <BusRouteStopList
+        <RouteStopList
           id={this.state.routeId}
           routeNumber={this.state.routeNumber}
           timepoints={this.state[this.state.currentSvc][this.state.currentDirection].stops}

--- a/src/components/Nearby.js
+++ b/src/components/Nearby.js
@@ -1,23 +1,22 @@
-import React from 'react';
-import {geolocated} from 'react-geolocated';
-import StopsNearLocation from './StopsNearLocation';
-import TopNav from './TopNav';
+import React from 'react'
+import { geolocated } from 'react-geolocated'
+
+import StopsNearLocation from './StopsNearLocation'
 
 class Nearby extends React.Component {
-
   render() {
-    return !this.props.isGeolocationAvailable
-      ? <div>Your browser does not support Geolocation</div>
-      : !this.props.isGeolocationEnabled
-        ? <div>Geolocation is not enabled</div>
-        : this.props.coords
+    return (
+      !this.props.isGeolocationAvailable
+      ? <div>Your browser does not support Geolocation</div> : !this.props.isGeolocationEnabled
+        ? <div>Geolocation is not enabled</div> : this.props.coords
           ? 
           <div className="nearby">
-          <div className="pa3 schedule">
-            <StopsNearLocation coords={this.props.coords} />
+            <div className="pa3 schedule">
+              <StopsNearLocation coords={this.props.coords} />
+            </div>
           </div>
-          </div>
-          : <div>Getting the location data&hellip; </div>;
+          : <div>Getting the location data&hellip;</div>
+    )
   }
 }
  

--- a/src/components/RealtimeTrip.js
+++ b/src/components/RealtimeTrip.js
@@ -1,36 +1,27 @@
-import React, { Component } from 'react';
-import { Link } from 'react-router-dom';
+import React, { Component } from 'react'
+import { Link } from 'react-router-dom'
 
-import Stops from '../data/stops.js';
-import Colors from '../data/colors.js';
-import chroma from 'chroma-js';
+import Stops from '../data/stops.js'
 import SchedSVG from '../img/schedule.svg'
 import LiveSVG from '../img/speaker_phone.svg'
 
 export default class RealtimeTrip extends Component {
   render() {
     return (
-      <div 
-        className="w-100 pa1 flex justify-between bb pa2" 
-        // style={{
-        //   backgroundColor: `rgba(${chroma(Colors[this.props.trip.properties.direction]).alpha(0.5).rgba().toString()})`,
-        // }}
-        >
-        <div style={{display: 'flex', alignItems: 'center'}}>
-          {this.props.trip.properties.predicted ?
+      <div className="w-100 pa1 flex justify-between bb pa2" >
+        <div style={{ display: 'flex', alignItems: 'center' }}>
+          { this.props.trip.properties.predicted ?
             <img src={LiveSVG} alt="Showing real-time prediction" />
-            :
-            <img src={SchedSVG} alt="Showing scheduled time" />
-          }
+            : <img src={SchedSVG} alt="Showing scheduled time" /> }
           <div className="ml2 pa1">
             <span className="fw7 f6 db">
               Trip #{this.props.trip.properties.tripId.slice(-4)}
             </span>
             <span className="f5 fw7 db pv1">
-            next stop:  
-            <Link className="pl1" to={{pathname: `/stop/${this.props.trip.properties.nextStop.slice(5)}/`}} >
-              {Stops[this.props.trip.properties.nextStop.slice(5)].name}
-            </Link>
+              next stop:  
+              <Link className="pl1" to={{pathname: `/stop/${this.props.trip.properties.nextStop.slice(5)}/`}} >
+                {Stops[this.props.trip.properties.nextStop.slice(5)].name}
+              </Link>
             </span>
             <span className="f6 fw3 db">
               {this.props.trip.properties.nextStopOffset > 60 ? `in ${Math.floor(this.props.trip.properties.nextStopOffset/60)} minute(s)` : ` now`}
@@ -38,8 +29,7 @@ export default class RealtimeTrip extends Component {
             </span>
           </div>
         </div>
-
       </div>
-    );
+    )
   }
 }

--- a/src/components/RealtimeTripList.js
+++ b/src/components/RealtimeTripList.js
@@ -1,11 +1,10 @@
-import React, { Component } from 'react';
-import RealtimeTrip from './RealtimeTrip';
-import chroma from 'chroma-js';
+import React, { Component } from 'react'
+import chroma from 'chroma-js'
+import _ from 'lodash'
+
+import RealtimeTrip from './RealtimeTrip'
 import Colors from '../data/colors.js'
-
 import Stops from '../data/stops.js'
-
-import _ from 'lodash';
 
 export default class RealtimeTripList extends Component {
   render() {
@@ -17,22 +16,19 @@ export default class RealtimeTripList extends Component {
           <div className="" key={dir}>
             <span 
               className="db pa2 f5 f4-ns fw7 white"
-              style={{
-                backgroundColor: `rgba(${chroma(Colors[dir]).rgba().toString()})`,
-              }}
-              >
-               {_.capitalize(dir)} to {Stops[this.props.route.schedules.weekday[dir].stops.slice(-1,)].name}
-               <br />
-               {byDirection[dir].length > 0 ? byDirection[dir].length : 'no'} {byDirection[dir].length == 1 ? `bus` : `buses`}
+              style={{ backgroundColor: `rgba(${chroma(Colors[dir]).rgba().toString()})` }}>
+                {_.capitalize(dir)} to {Stops[this.props.route.schedules.weekday[dir].stops.slice(-1,)].name}
+                <br />
+                {byDirection[dir].length > 0 ? byDirection[dir].length : 'no'} {byDirection[dir].length === 1 ? `bus` : `buses`}
             </span>
             {_.sortBy(byDirection[dir], 'properties.scheduledDistanceAlongTrip').map((t, i) =>
               <div>
-              <RealtimeTrip trip={t} key={t.properties.tripId} />
+                <RealtimeTrip trip={t} key={t.properties.tripId} />
               </div>
             )}
           </div>
         )}
       </div>
-    );
+    )
   }
 }

--- a/src/components/RealtimeTripList.js
+++ b/src/components/RealtimeTripList.js
@@ -12,8 +12,8 @@ export default class RealtimeTripList extends Component {
 
     return (
       <div className="list overflow-scroll">
-        {Object.keys(byDirection).map(dir =>
-          <div className="" key={dir}>
+        {Object.keys(byDirection).map((dir, i) =>
+          <div key={i}>
             <span 
               className="db pa2 f5 f4-ns fw7 white"
               style={{ backgroundColor: `rgba(${chroma(Colors[dir]).rgba().toString()})` }}>
@@ -22,7 +22,7 @@ export default class RealtimeTripList extends Component {
                 {byDirection[dir].length > 0 ? byDirection[dir].length : 'no'} {byDirection[dir].length === 1 ? `bus` : `buses`}
             </span>
             {_.sortBy(byDirection[dir], 'properties.scheduledDistanceAlongTrip').map((t, i) =>
-              <div>
+              <div key={i}>
                 <RealtimeTrip trip={t} key={t.properties.tripId} />
               </div>
             )}

--- a/src/components/RouteHeader.js
+++ b/src/components/RouteHeader.js
@@ -1,12 +1,12 @@
-import React from 'react';
+import React from 'react'
 import { Link } from 'react-router-dom'
 
 import ddotRoutes from '../data/routes.js'
 
-const LineHeader = ({ color, number, name }) => (
+const RouteHeader = ({ color, number, name }) => (
   <div className="pv3 ph3 bg-white bg-o-50 header bb">
     <div style={{ display: 'flex', alignItems: 'center' }}>
-      <Link className="link dim dark-gray v-mid mr2" to={{pathname: `/`}}>
+      <Link className="link dim dark-gray v-mid mr2" to={{ pathname: `/` }}>
         <div className="fw7 f7 f6-ns pa2 bg-moon-gray ba">&lt;</div>
       </Link>
       <span className="dib f3-s f2-ns mh2 pa2 v-mid white fw7" style={{ backgroundColor: color }}>
@@ -20,10 +20,14 @@ const LineHeader = ({ color, number, name }) => (
           {ddotRoutes[number].description}
         </span>
       </div>
-    <Link className="link dim dark-gray ma2" to={{pathname: `/route/${number}/real-time`}}><div className="fw7 f7 f6-ns pa2 bg-moon-gray ba ">Live</div></Link>
-    <Link className="link dim dark-gray ma2" to={{pathname: `/route/${number}/schedule`}}><div className="fw7 f7 f6-ns pa2 bg-moon-gray ba">Schedule</div></Link>
+    <Link className="link dim dark-gray ma2" to={{ pathname: `/route/${number}/real-time` }}>
+      <div className="fw7 f7 f6-ns pa2 bg-moon-gray ba ">Live</div>
+    </Link>
+    <Link className="link dim dark-gray ma2" to={{ pathname: `/route/${number}/schedule` }}>
+      <div className="fw7 f7 f6-ns pa2 bg-moon-gray ba">Schedule</div>
+    </Link>
     </div>
   </div>
-);
+)
 
-export default LineHeader;
+export default RouteHeader

--- a/src/components/RouteInput.js
+++ b/src/components/RouteInput.js
@@ -1,22 +1,22 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-class LineInput extends Component {
+class RouteInput extends Component {
   render() {
     return (
       <div  className="f5 ml2 w-75">
       <input className="w-90 pa2"
-              placeholder="Search for a line name or number."
-              value={this.props.input}
-              onChange={this.props.onSearchChange} />
+        placeholder="Search for a route name or number"
+        value={this.props.input}
+        onChange={this.props.onSearchChange} />
       </div>
     )
   }
 }
 
-LineInput.propTypes = {
+RouteInput.propTypes = {
   input: PropTypes.string.isRequired,
   onSearchChange: PropTypes.func.isRequired,
 }
 
-export default LineInput;
+export default RouteInput;

--- a/src/components/RouteLink.js
+++ b/src/components/RouteLink.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 
 import Schedules from '../data/schedules.js'
 
-class LineLink extends Component {
+class RouteLink extends Component {
   render() {
     const route = Schedules[this.props.id]
 
@@ -24,8 +24,8 @@ class LineLink extends Component {
   }
 }
 
-LineLink.propTypes = {
+RouteLink.propTypes = {
   id: PropTypes.string.isRequired,
 }
 
-export default LineLink
+export default RouteLink

--- a/src/components/RoutePredictionList.js
+++ b/src/components/RoutePredictionList.js
@@ -1,22 +1,22 @@
 import React from 'react'
-import moment from 'moment';
+import moment from 'moment'
+
 import SchedSVG from '../img/schedule.svg'
 import LiveSVG from '../img/speaker_phone.svg'
 
 const RoutePredictionList = ({ predictions, route }) => (
-  <div className="ml3" style={{display: 'flex', alignItems: 'center', flexWrap: 'wrap'}}>
-    {predictions.map(p => (
-      <div className="pa2 ma1 bg-moon-gray dib" style={{display: 'flex', alignItems: 'center'}}>
-              <span className="dib">arriving at {p.predicted ? moment(p.predictedArrivalTime).format('h:mma') : moment(p.scheduledArrivalTime).format('h:mma')}</span>
-
-          {p.predicted ?
-            <img className="ml1" src={LiveSVG} alt="Showing real-time prediction" />
-            :
-            <img className="ml1" src={SchedSVG} alt="Showing scheduled time" />
-          }
+  <div className="ml3" style={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap' }}>
+    {predictions.map((p, i) => (
+      <div className="pa2 ma1 bg-moon-gray dib" style={{ display: 'flex', alignItems: 'center' }} key={i}>
+        <span className="dib">
+          arriving at {p.predicted ? moment(p.predictedArrivalTime).format('h:mma') : moment(p.scheduledArrivalTime).format('h:mma')}
+        </span>
+        {p.predicted ?
+          <img className="ml1" src={LiveSVG} alt="Showing real-time prediction" />
+          :<img className="ml1" src={SchedSVG} alt="Showing scheduled time" />}
       </div>
     ))}
   </div>
 ) 
 
-export default RoutePredictionList;
+export default RoutePredictionList

--- a/src/components/RouteSchedule.js
+++ b/src/components/RouteSchedule.js
@@ -1,20 +1,23 @@
-import React from 'react'
-import PropTypes from 'prop-types'
-import moment from 'moment'
-import _ from 'lodash'
+import React from 'react';
+import PropTypes from 'prop-types';
+import moment from 'moment';
+import _ from 'lodash';
 
-import RouteMap from './RouteMap'
-import RealtimeTripList from './RealtimeTripList'
-import RouteHeader from './RouteHeader'
-import Helpers from '../helpers'
+import ScheduleTable from './ScheduleTable';
+import ServicePicker from './ServicePicker';
+import DirectionPicker from './DirectionPicker';
+import RouteHeader from './RouteHeader';
+import RouteStopList from './RouteStopList'
 
-class LineRealTime extends React.Component {
+import Helpers from '../helpers';
+
+class RouteSchedule extends React.Component {
   constructor(props) {
-    super(props)
+    super(props);
 
     let route = Helpers.getRoute(parseInt(this.props.match.params.name, 10))
+
     let tripIds = {}
-    
     Object.keys(route.schedules).forEach(svc => {
       Object.keys(route.schedules.weekday).forEach(dir => {
         if (!tripIds[dir]) {
@@ -25,9 +28,9 @@ class LineRealTime extends React.Component {
     })
 
     this.state = {
-      route: (route),
       routeName: (route.rt_name),
       routeId: (route.rt_id),
+      routeNumber: parseInt(this.props.match.params.name, 10),
       description: (route.description),
       weekday: (route.schedules.weekday),
       saturday: (route.schedules.saturday),
@@ -37,21 +40,21 @@ class LineRealTime extends React.Component {
       color: (route.color),
       currentSvc: (Object.keys(route.schedules).length > 1 ? Helpers.dowToService(moment().day()) : 'weekday'),
       currentDirection: (Object.keys(route.schedules.weekday)[0]),
+      currentStops: [],
       availableServices: (Object.keys(route.schedules)),
       availableDirections: (Object.keys(route.schedules.weekday)),
       routeBbox: route.bbox,
-      timepointStops: route.timepoints[Object.keys(route.schedules.weekday)[0]]
-    }
+    };
 
-    this.handleDirectionChange = this.handleDirectionChange.bind(this)
-    this.handleServiceChange = this.handleServiceChange.bind(this)
+    this.handleDirectionChange = this.handleDirectionChange.bind(this);
+    this.handleServiceChange = this.handleServiceChange.bind(this);
   }
 
   fetchData() {
     fetch(`https://ddot-proxy-test.herokuapp.com/api/where/trips-for-route/DDOT_${this.state.routeId}.json?key=BETA&includeStatus=true&includePolylines=false`)
     .then(response => response.json())
     .then(d => {
-      let geojson = _.sortBy(d.data.list, 'status.tripId').map((bus, i) => {
+      let geojson = d.data.list.map(bus => {
         return {
           "type": "Feature",
           "geometry": {
@@ -60,8 +63,6 @@ class LineRealTime extends React.Component {
           },
           "properties": {
             "tripId": bus.status.activeTripId,
-            "displayTripId": bus.status.activeTripId.slice(-4,),
-            "scheduledDistanceAlongTrip": bus.status.scheduledDistanceAlongTrip,
             "nextStop": bus.status.nextStop,
             "nextStopOffset": bus.status.nextStopTimeOffset,
             "predicted": bus.status.predicted,
@@ -71,29 +72,29 @@ class LineRealTime extends React.Component {
           }
         }
       })
+
       let realtimeTrips = _.filter(geojson, o => { return o.properties.direction !== undefined })
-      this.setState({ 
-        realtimeTrips: realtimeTrips 
-      })
+      this.setState({realtimeTrips: realtimeTrips})
+
     })
-    .catch(e => console.log(e))
+    .catch(e => console.log(e));
   }
 
   handleDirectionChange(event) {
     this.setState({
       currentDirection: event.target.value
-    })
+    });
   }
 
   handleServiceChange(event) {
     this.setState({
       currentSvc: event.target.value
-    })
+    });
   }
 
   componentDidMount() {
     this.fetchData()
-    this.interval = setInterval(() => this.fetchData(), 3000)
+    this.interval = setInterval(() => this.fetchData(), 3000);
   }
 
   componentWillUnmount() {
@@ -104,22 +105,36 @@ class LineRealTime extends React.Component {
     return (
       <div className="App">
         <RouteHeader color={this.state.color} number={this.props.match.params.name} name={this.state.routeName} />
-        <RouteMap 
-          routeId={this.props.match.params.name} 
-          stops={this.state.timepointStops} 
-          bbox={this.state.routeBbox} 
-          trips={this.state.realtimeTrips} 
-        />
-        <RealtimeTripList
-          trips={this.state.realtimeTrips}
-          route={this.state.route}
+        <div className="pickers">
+          <ServicePicker 
+            services={this.state.availableServices}
+            currentSvc={this.state.currentSvc}
+            onChange={this.handleServiceChange}
+          />
+          <DirectionPicker 
+            directions={this.state.availableDirections}
+            currentDirection={this.state.currentDirection}
+            onChange={this.handleDirectionChange} 
+          />
+          <h2>Stops on this schedule</h2>
+        </div>
+        <RouteStopList
+          id={this.state.routeId}
+          routeNumber={this.state.routeNumber}
+          timepoints={this.state[this.state.currentSvc][this.state.currentDirection].stops}
+          />
+        <ScheduleTable 
+          schedule={this.state[this.state.currentSvc]} 
+          direction={this.state.currentDirection} 
+          liveTrips={_.map(this.state.realtimeTrips, 'properties.tripId')} 
+          color={this.state.color}
         />
       </div>
     )
   }
 }
 
-LineRealTime.propTypes = {
+RouteSchedule.propTypes = {
   match: PropTypes.shape({
     isExact: PropTypes.bool,
     params: PropTypes.shape({
@@ -130,4 +145,4 @@ LineRealTime.propTypes = {
   }).isRequired,
 }
 
-export default LineRealTime
+export default RouteSchedule;

--- a/src/components/RouteSearch.js
+++ b/src/components/RouteSearch.js
@@ -1,10 +1,10 @@
 import React, { Component } from 'react';
 
-import LineInput from './LineInput';
+import RouteInput from './RouteInput';
 import LinesList from './LinesList';
 import Schedules from '../data/schedules';
 
-class LineSearch extends Component {
+class RouteSearch extends Component {
   constructor(props) {
     super(props);
 
@@ -22,10 +22,12 @@ class LineSearch extends Component {
     fetch('https://ddot-proxy-test.herokuapp.com/api/where/routes-for-agency/DDOT.json?key=BETA')
       .then(response => response.json())
       .then(d => {
-        let sorted = d.data.list.sort((a,b)=>{
+        let sorted = d.data.list.sort((a,b) => {
           return parseInt(a.id, 10) > parseInt(b.id, 10);
         })
-        this.setState({realTime: sorted})
+        this.setState({
+          realTime: sorted
+        })
       })
   }
 
@@ -34,25 +36,26 @@ class LineSearch extends Component {
     const matched = []
 
     this.state.allLines.forEach(ln => {
-      if (
-          (ln.id.indexOf(val) > -1) || 
-          (ln.rt_name.toUpperCase().indexOf(val.toUpperCase()) > -1)) {
+      if ((ln.id.indexOf(val) > -1) || (ln.rt_name.toUpperCase().indexOf(val.toUpperCase()) > -1)) {
         matched.push(ln);
       }
     })
 
-    this.setState({ input: event.target.value, filteredLines: matched });
+    this.setState({ 
+      input: event.target.value, 
+      filteredLines: matched 
+    });
   }
 
-  render () {
+  render() {
     return (
       <div className="search overflow-scroll pa2 br">
         <span className="fw7 f4 pa2 dib">Already know what route you're looking for?</span>
-        <LineInput input={this.state.input} onSearchChange={this.handleSearchChange} />
+        <RouteInput input={this.state.input} onSearchChange={this.handleSearchChange} />
         { this.state.filteredLines.length > 0 ? <LinesList lines={this.state.filteredLines} /> : <p><strong>Loading...</strong></p> }
       </div>
     )
   }
 }
 
-export default LineSearch;
+export default RouteSearch;

--- a/src/components/RouteSearch.js
+++ b/src/components/RouteSearch.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 
 import RouteInput from './RouteInput';
-import LinesList from './LinesList';
+import RoutesList from './RoutesList';
 import Schedules from '../data/schedules';
 
 class RouteSearch extends Component {
@@ -52,7 +52,7 @@ class RouteSearch extends Component {
       <div className="search overflow-scroll pa2 br">
         <span className="fw7 f4 pa2 dib">Already know what route you're looking for?</span>
         <RouteInput input={this.state.input} onSearchChange={this.handleSearchChange} />
-        { this.state.filteredLines.length > 0 ? <LinesList lines={this.state.filteredLines} /> : <p><strong>Loading...</strong></p> }
+        { this.state.filteredLines.length > 0 ? <RoutesList lines={this.state.filteredLines} /> : <p><strong>Loading...</strong></p> }
       </div>
     )
   }

--- a/src/components/RouteStopList.js
+++ b/src/components/RouteStopList.js
@@ -4,7 +4,7 @@ import _ from 'lodash'
 import StopLink from './StopLink'
 import Stops from '../data/stops.js'
 
-class BusRouteStopList extends Component {
+class RouteStopList extends Component {
   constructor(props) {
     super(props)
     this.state = {
@@ -47,4 +47,4 @@ class BusRouteStopList extends Component {
   }
 }
 
-export default BusRouteStopList
+export default RouteStopList

--- a/src/components/RoutesList.js
+++ b/src/components/RoutesList.js
@@ -1,15 +1,15 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-import LineLink from './LineLink';
+import RouteLink from './RouteLink';
 
-class LinesList extends Component {
+class RoutesList extends Component {
   render() {
     return (
       <div className="overflow-scroll vh-75 ba ma2">
           {this.props.lines.map(line =>
             <div className="ph3 pv2 bb b--light-silver" key={line.id}>
-              <LineLink key={line.id} id={line.id} routeId={line.rt_id} name={line.rt_name} color={line.color} />
+              <RouteLink key={line.id} id={line.id} routeId={line.rt_id} name={line.rt_name} color={line.color} />
             </div>
           )}
       </div>
@@ -17,7 +17,7 @@ class LinesList extends Component {
   }
 }
 
-LinesList.propTypes = {
+RoutesList.propTypes = {
   lines: PropTypes.arrayOf(PropTypes.shape({
     agencyId: PropTypes.string,
     color: PropTypes.string,
@@ -29,4 +29,4 @@ LinesList.propTypes = {
   })).isRequired,
 }
 
-export default LinesList;
+export default RoutesList;

--- a/src/components/Stop.js
+++ b/src/components/Stop.js
@@ -9,7 +9,6 @@ import StopRouteList from './StopRouteList';
 
 
 class Stop extends React.Component {
-
   constructor(props) {
     super(props)
 
@@ -23,7 +22,10 @@ class Stop extends React.Component {
     fetch(`https://ddot-proxy-test.herokuapp.com/api/where/arrivals-and-departures-for-stop/DDOT_${this.props.match.params.name}.json?key=BETA&includePolylines=false`)
     .then(response => response.json())
     .then(d => {
-      this.setState({ predictions: d, fetchedPredictions: true })
+      this.setState({ 
+        predictions: d, 
+        fetchedPredictions: true 
+      })
     })
     .catch(e => console.log(e));
   }

--- a/src/components/StopLink.js
+++ b/src/components/StopLink.js
@@ -16,9 +16,11 @@ class StopLink extends Component {
           to={{ pathname: `/stop/${this.props.id}/` }}>
           {Stops[this.props.id] ? Stops[this.props.id].name : ``}
         </Link>
-        {Stops[this.props.id] ? Stops[this.props.id].routes.map(r => (
-          <span className={exclude.toString() === r.toString() ? "dn" : "pa1 dib white fw7 f7 ma1"} style={{backgroundColor: Schedules[r].color}}>
-            <Link className="white dim glow" to={{pathname: `/route/${r}`}}>{r}</Link>
+        {Stops[this.props.id] ? Stops[this.props.id].routes.map((r, i) => (
+          <span className={exclude.toString() === r.toString() ? "dn" : "pa1 dib white fw7 f7 ma1"} 
+            style={{ backgroundColor: Schedules[r].color }}
+            key={i}>
+              <Link className="white dim glow" to={{pathname: `/route/${r}`}}>{r}</Link>
           </span>
         )) : `FAILED`}
       </div>

--- a/src/components/StopLink.js
+++ b/src/components/StopLink.js
@@ -1,19 +1,25 @@
-import React, { Component } from 'react';
-import { Link } from 'react-router-dom';
-import PropTypes from 'prop-types';
-import Stops from '../data/stops.js';
+import React, { Component } from 'react'
+import { Link } from 'react-router-dom'
+import PropTypes from 'prop-types'
+
+import Stops from '../data/stops.js'
 import Schedules from '../data/schedules.js'
-import _ from 'lodash';
 
 class StopLink extends Component {
   render() {
     const exclude = this.props.exclude || ''
 
     return (
-      <div className="h2" style={{display: 'flex', alignItems: 'center', justifyContent:'justify-between'}}>
-        <Link className="dim black hover-mid-gray glow mr1" to={{pathname: `/stop/${this.props.id}/`}}>{Stops[this.props.id] ? Stops[this.props.id].name : ``}</Link>
+      <div className="h2" style={{ display: 'flex', alignItems: 'center', justifyContent:'justify-between' }}>
+        <Link 
+          className="dim black hover-mid-gray glow mr1" 
+          to={{ pathname: `/stop/${this.props.id}/` }}>
+          {Stops[this.props.id] ? Stops[this.props.id].name : ``}
+        </Link>
         {Stops[this.props.id] ? Stops[this.props.id].routes.map(r => (
-          <span className={exclude.toString() === r.toString() ? "dn" : "pa1 dib white fw7 f7 ma1"} style={{backgroundColor: Schedules[r].color}}><Link className="white dim glow" to={{pathname: `/route/${r}`}}>{r}</Link></span>
+          <span className={exclude.toString() === r.toString() ? "dn" : "pa1 dib white fw7 f7 ma1"} style={{backgroundColor: Schedules[r].color}}>
+            <Link className="white dim glow" to={{pathname: `/route/${r}`}}>{r}</Link>
+          </span>
         )) : `FAILED`}
       </div>
     )
@@ -22,7 +28,7 @@ class StopLink extends Component {
 
 StopLink.propTypes = {
   id: PropTypes.string.isRequired,
-  exclude: PropTypes.number
+  exclude: PropTypes.number,
 }
 
-export default StopLink;
+export default StopLink

--- a/src/components/StopRouteList.js
+++ b/src/components/StopRouteList.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import _ from 'lodash'
 
 import Schedules from '../data/schedules.js'
-import LineLink from './LineLink'
+import RouteLink from './RouteLink'
 import RoutePredictionList from './RoutePredictionList'
 
 class StopRouteList extends Component {
@@ -15,7 +15,7 @@ class StopRouteList extends Component {
       <div className='list overflow-scroll'>
         {routes.map((r, i) => (
           <div className="pa2 bb" style={{ display: 'flex', alignItems: 'center' }} key={i}>
-            <LineLink name={Schedules[r].rt_name} id={r} color={Schedules[r].color} />
+            <RouteLink name={Schedules[r].rt_name} id={r} color={Schedules[r].color} />
             <RoutePredictionList predictions={_.filter(goodPredictions, function(o) { 
               return o.routeShortName === r.padStart(3, '0')})} route={r} />
           </div>

--- a/src/components/StopRouteList.js
+++ b/src/components/StopRouteList.js
@@ -13,8 +13,8 @@ class StopRouteList extends Component {
 
     return (
       <div className='list overflow-scroll'>
-        {routes.map(r => (
-          <div className="pa2 bb" style={{ display: 'flex', alignItems: 'center' }}>
+        {routes.map((r, i) => (
+          <div className="pa2 bb" style={{ display: 'flex', alignItems: 'center' }} key={i}>
             <LineLink name={Schedules[r].rt_name} id={r} color={Schedules[r].color} />
             <RoutePredictionList predictions={_.filter(goodPredictions, function(o) { 
               return o.routeShortName === r.padStart(3, '0')})} route={r} />

--- a/src/components/StopRouteList.js
+++ b/src/components/StopRouteList.js
@@ -1,23 +1,23 @@
-import React, { Component } from 'react';
-import Schedules from '../data/schedules.js';
-import LineLink from './LineLink'
-import _ from 'lodash';
-import moment from 'moment';
+import React, { Component } from 'react'
+import _ from 'lodash'
 
-import RoutePredictionList from './RoutePredictionList';
+import Schedules from '../data/schedules.js'
+import LineLink from './LineLink'
+import RoutePredictionList from './RoutePredictionList'
 
 class StopRouteList extends Component {
-  render () {
+  render() {
     const predictions = this.props.predictions
-    const goodPredictions = this.props.predictions.data.entry.arrivalsAndDepartures
-    // const goodPredictions = _.filter(this.props.predictions.data.entry.arrivalsAndDepartures, a => { return a.predictedArrivalTime > 0 })
+    const goodPredictions = predictions.data.entry.arrivalsAndDepartures
     const routes = this.props.routes
+
     return (
       <div className='list overflow-scroll'>
         {routes.map(r => (
-          <div className="pa2 bb" style={{display: 'flex', alignItems: 'center'}}>
+          <div className="pa2 bb" style={{ display: 'flex', alignItems: 'center' }}>
             <LineLink name={Schedules[r].rt_name} id={r} color={Schedules[r].color} />
-            <RoutePredictionList predictions={_.filter(goodPredictions, function(o) { return o.routeShortName === r.padStart(3, '0')})} route={r} />
+            <RoutePredictionList predictions={_.filter(goodPredictions, function(o) { 
+              return o.routeShortName === r.padStart(3, '0')})} route={r} />
           </div>
         ))}
       </div>
@@ -25,4 +25,4 @@ class StopRouteList extends Component {
   }
 }
 
-export default StopRouteList;
+export default StopRouteList

--- a/src/components/StopsNearLocation.js
+++ b/src/components/StopsNearLocation.js
@@ -1,13 +1,9 @@
 import React, { Component } from 'react';
-import _ from 'lodash';
-// import PropTypes from 'prop-types';
-import StopLink from './StopLink';
-import LineLink from './LineLink';
-// import Schedules from '../data/schedules.js';
-import Stops from '../data/stops.js'
+
+import StopLink from './StopLink'
+import LineLink from './LineLink'
 
 class StopsNearLocation extends Component {
-
   constructor(props) {
     super(props)
     this.state = {
@@ -21,7 +17,10 @@ class StopsNearLocation extends Component {
     .then(response => response.json())
     .then(d => {
       console.log(d)
-      this.setState({data: d, fetchedData: true})
+      this.setState({
+        data: d, 
+        fetchedData: true
+      })
     })
     .catch(e => console.log(e));
   }
@@ -32,6 +31,7 @@ class StopsNearLocation extends Component {
 
   render() {
     let data = this.state.fetchedData ? this.state.data : null
+
     return (
       <div>
         <div>
@@ -57,4 +57,4 @@ class StopsNearLocation extends Component {
   }
 }
 
-export default StopsNearLocation;
+export default StopsNearLocation

--- a/src/components/StopsNearLocation.js
+++ b/src/components/StopsNearLocation.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 
 import StopLink from './StopLink'
-import LineLink from './LineLink'
+import RouteLink from './RouteLink'
 
 class StopsNearLocation extends Component {
   constructor(props) {
@@ -38,7 +38,7 @@ class StopsNearLocation extends Component {
           <div className="h5 overflow-scroll">
             {this.state.fetchedData ? data.data.references.routes.map((r, i) => (
               <div className="bg-light-gray ma2 pa2" key={i}>
-                <LineLink id={parseInt(r.shortName, 10)}/>
+                <RouteLink id={parseInt(r.shortName, 10)}/>
               </div>
             )) : ``}
           </div>

--- a/src/components/StopsNearLocation.js
+++ b/src/components/StopsNearLocation.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component } from 'react'
 
 import StopLink from './StopLink'
 import LineLink from './LineLink'
@@ -16,7 +16,6 @@ class StopsNearLocation extends Component {
     fetch(`https://ddot-proxy-test.herokuapp.com/api/where/stops-for-location.json?key=BETA&radius=500&lat=${this.props.coords.latitude}&lon=${this.props.coords.longitude}`)
     .then(response => response.json())
     .then(d => {
-      console.log(d)
       this.setState({
         data: d, 
         fetchedData: true
@@ -37,8 +36,8 @@ class StopsNearLocation extends Component {
         <div>
           <h4>Nearby routes:</h4>
           <div className="h5 overflow-scroll">
-            {this.state.fetchedData ? data.data.references.routes.map(r => (
-              <div className="bg-light-gray ma2 pa2">
+            {this.state.fetchedData ? data.data.references.routes.map((r, i) => (
+              <div className="bg-light-gray ma2 pa2" key={i}>
                 <LineLink id={parseInt(r.shortName, 10)}/>
               </div>
             )) : ``}
@@ -47,8 +46,8 @@ class StopsNearLocation extends Component {
         <div>
           <h4>Nearby stops:</h4>
           <div className="h4 overflow-scroll">
-            {this.state.fetchedData ? data.data.list.map(a => (
-              <StopLink id={a.id.slice(5,)} />
+            {this.state.fetchedData ? data.data.list.map((a, i) => (
+              <StopLink id={a.id.slice(5,)} key={i} />
             )) : ``}
           </div>
         </div>

--- a/src/index.js
+++ b/src/index.js
@@ -7,8 +7,8 @@ import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
 import './css/index.css';
 import App from './App';
 import About from './components/About';
-import LineRealTime from './components/LineRealTime';
-import LineSchedule from './components/LineSchedule';
+import RouteRealtime from './components/RouteRealtime';
+import RouteSchedule from './components/RouteSchedule';
 import Stop from './components/Stop';
 import Nearby from './components/Nearby';
 
@@ -43,8 +43,8 @@ ReactDOM.render(
         <Route path='/about' component={About} />
         <Route path='/nearby' component={Nearby} />
         <Route path='/stop/:name' component={Stop} />
-        <Route path="/route/:name/real-time" component={LineRealTime} />
-        <Route path="/route/:name/schedule" component={LineSchedule} />
+        <Route path="/route/:name/real-time" component={RouteRealtime} />
+        <Route path="/route/:name/schedule" component={RouteSchedule} />
       </Switch>
     </GAListener>
   </Router>,


### PR DESCRIPTION
- calling bus routes "lines" was confusing, so all components consistently use "route" and "stop" now
- lots of small formatting tweaks to clean up console and linter errors and make things more readable

fixes #22